### PR TITLE
develop

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,9 +64,9 @@ The notebook is designed to be run in a pre-configured cloud-computing environme
 
 [![Launch Terminal](../badges/terminal.svg)]{{ page.terminal_popup }}
 
-1. Click on the [**Launch Terminal**] button above.
+1. Click on the [**Launch Terminal**]{{ page.terminal_popup }} button above.
 2. A Binder instance will launch in a new tab with the message *Starting Repository*.
-3. Wait patiently and do not close the Binder tab. After a few minutes, a Terminal instance will launch.
+3. Wait patiently and do not close the Binder tab. After a few minutes, a **Terminal** instance will launch.
 4. To launch a Python interpreter, type `python` and press <kbd>Enter</kbd> or <kbd>Return</kbd>.
 
 ---
@@ -76,7 +76,8 @@ The notebook is designed to be run in a pre-configured cloud-computing environme
     - **Windows (Anaconda)**: *Start > Anaconda3 > Anaconda PowerShell Prompt*
     - **Windows (Mambaforge)**: *Start > Mambaforge > Mambaforge Prompt*
     - **macOS**: *Applications > Utilities > Terminal*
-2. Ensure last line of text in the Terminal or Prompt begins `(base)`. If this is not the case, use a [*Virtual Terminal*](#virtual-terminal) instead.
+2. Ensure the last line of text in the Terminal or Prompt begins with `(base)`.
+    - *If this is not the case, use a [__Virtual Terminal__](#virtual-terminal) instead.*
 3. To launch a Python interpreter, type `python` and press <kbd>Enter</kbd> or <kbd>Return</kbd>.
 
 ---


### PR DESCRIPTION
- merge notebook updates from chbe39-intro-python
- simplify notebook header section
- update notebook intro and list sections
- explicitly specify in-text urls using angle brackets
- update and fix notebook dictionaries section
- specify difference between print and return
- update notebook loops section
- update notebook advanced sections
- update resources section and fix typos
- simplify environment specification
- restructure repository to accomodate workflows
- add build-binder and mirror-content workflows
- add preliminary readme
- overhaul workshop website
- fix typos and clarify local terminal launch instructions
- fix notebook download link
- update binder and colab links
- update tarball and zipball links
- update local python interpreter instructions
- slim down google colab instructions
- update mambaforge local notebook launch instructions
- update section titles
- add workshop overview to website
- update command-line section to work with new terminal instance
- minor updates to readme
- fix errors in terminal launch instructions
