### PR TITLE
develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![workshop website][workshop-webiste-badge]][workshop-webiste-link]&nbsp;
 [![mirror content][mirror-content-badge]](../../actions/workflows/mirror-content.yml)&nbsp;
 [![build binder][build-binder-badge]](../../actions/workflows/build-binder.yml)&nbsp;
-[![last commit][last-commit-badge]](../../commits/main)
+[![last commit][last-commit-badge]](../../commits/main)&nbsp;
+[![launch develop][develop-launch-badge]][develop-launch-link]
 
 Source repository for the [Tufts University Data Lab][datalab-website-link] workshop: [*Introduction to Programming with Python*][workshop-webiste-link]
 
@@ -13,8 +14,10 @@ Source repository for the [Tufts University Data Lab][datalab-website-link] work
 
 [workshop-webiste-link]: https://tuftsdatalab.github.io/intro-python/
 [datalab-website-link]: https://sites.tufts.edu/datalab/
+[develop-launch-link]: https://mybinder.org/v2/gh/tuftsdatalab/intro-python/develop?urlpath=lab
 
 [workshop-webiste-badge]: https://img.shields.io/website?label=workshop%20webiste&url=https://tuftsdatalab.github.io/intro-python/
 [mirror-content-badge]: https://img.shields.io/github/workflow/status/tuftsdatalab/intro-python/mirror-content?label=mirror%20content
 [build-binder-badge]: https://img.shields.io/github/workflow/status/tuftsdatalab/intro-python/build-binder?label=build%20binder
 [last-commit-badge]: https://img.shields.io/github/last-commit/tuftsdatalab/intro-python
+[develop-launch-badge]: https://tuftsdatalab.github.io/badges/develop.svg

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,2 @@
 #!/bin/bash
-jupyter lab build --dev-build=False --minimize=False
+jupyter lab build --dev-build=False --minimize=True

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ Contact: <datalab-support@elist.tufts.edu>
     - [Running the Notebook using Google Colab](#colab)
     - [Running the Notebook using a Local Anaconda Installation](#anaconda)
     - [Running the Notebook using a Local Mambaforge Installation](#mambaforge)
+- [Additional Resources](#resources)
 
 ---
 ## Workshop Overview {#overview}
@@ -137,6 +138,18 @@ The notebook is designed to be run in a pre-configured cloud-computing environme
 3. JupyterLab will launch in a web browser. (A new tab will be generated if a browser is already open.)
 4. If the workshop notebook does not automatically open, *double-click* on `{{ site.file }}` in the file browser on the left.
 5. **Do not close the console!** Closing the console will also terminate JupyterLab. Leave the console running in the background.
+
+---
+## Additional Resources
+
+- Kaggle Python Course: <https://www.kaggle.com/learn/python>
+- W3Schools Python Tutorial: <https://www.w3schools.com/python>
+- Google's Python Class: <https://developers.google.com/edu/python>
+- Official Python Tutorial: <https://docs.python.org/3/tutorial>
+
+Software Carpentry Lessons
+- Programming with Python: <https://swcarpentry.github.io/python-novice-inflammation>
+- Plotting and Programming in Python: <http://swcarpentry.github.io/python-novice-gapminder>
 
 
 [binder-link]: https://mybinder.org/v2/gh/tuftsdatalab/{{ site.repo }}/binder?urlpath=lab/tree/{{ site.file }}

--- a/workshop/intro-python.ipynb
+++ b/workshop/intro-python.ipynb
@@ -2,33 +2,27 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "6DFAxibfbXbl"
-   },
+   "metadata": {},
    "source": [
     "# Introduction to Programming with Python\n",
     "\n",
     "---\n",
     "\n",
-    "**A Tufts University Data Lab Workshop**\\\n",
+    "**A Tufts University Data Lab Workshop**  \n",
     "Written by Uku-Kaspar Uustalu\n",
     "\n",
-    "Website: [tuftsdatalab.github.io/intro-python](https://tuftsdatalab.github.io/intro-python/)\\\n",
-    "Contact: <datalab-support@elist.tufts.edu>\\\n",
+    "Website: [tuftsdatalab.github.io/intro-python](https://tuftsdatalab.github.io/intro-python/)  \n",
+    "Contact: <datalab-support@elist.tufts.edu>  \n",
     "Resources: [datalab.tufts.edu](https://sites.tufts.edu/datalab/)\n",
     "\n",
-    "Last updated: `2021-10-25`\n",
+    "Last updated: `2022-03-16`\n",
     "\n",
     "---"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "U0jBRAQNbXbp"
-   },
+   "metadata": {},
    "source": [
     "## Introduction to Python Notebooks\n",
     "\n",
@@ -37,12 +31,12 @@
     "2. **Markdown** cells for text, images, LaTeX equations, etc.\n",
     "3. **Raw** cells for additional non-Python code that modifies the notebook when exporting it to a different format.\n",
     "\n",
-    "Each cell can be run (and re-run) independently.\\\n",
-    "To run a cell, select it by clicking on it and then press <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>.\\\n",
+    "Each cell can be run (and re-run) independently.  \n",
+    "To run a cell, select it by clicking on it and then press <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>.  \n",
     "After running a cell, the following cell gets automatically selected.\n",
     "\n",
-    "This is a **Markdown cell**. Markdown is a lightweight language for formatting text.\\\n",
-    "To see the code behind a Markdown cell, ***double-click*** on it.\\\n",
+    "This is a **Markdown cell**. Markdown is a lightweight language for formatting text.  \n",
+    "To see the code behind a Markdown cell, ***double-click*** on it.  \n",
     "To render the Markdown code back into formatted text, you must run the cell.\n",
     "\n",
     "Here are some useful Markdown references:\n",
@@ -69,14 +63,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "CnQh-qKWbXb9"
-   },
+   "metadata": {},
    "source": [
-    "&#8593;&#8593;&#8593;\\\n",
-    "The **output** of code cells appears right here in the notebook just below the corresponding cell.\\\n",
-    "Output is also stored in the notebook. Any output of a **saved** notebook will still be there after you close it and open it up again.\\\n",
+    "&#8593;&#8593;&#8593;  \n",
+    "The **output** of code cells appears right here in the notebook just below the corresponding cell.  \n",
+    "Output is also stored in the notebook. Any output of a **saved** notebook will still be there after you close it and open it up again.  \n",
     "If you run a cell again, the output will be overwritten. To clear outputs, go to *Edit > Clear All Outputs*."
    ]
   },
@@ -93,10 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "88b8ph5ibXcC"
-   },
+   "metadata": {},
    "source": [
     "### Understanding how Outputs Work\n",
     "The output from the last line in a block usually gets printed out (even without a print statement)."
@@ -105,11 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "5Lo7AxtPbXcG"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "spam = 500\n",
@@ -126,11 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "jpW9una2bXca"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "new_spam = spam * 2"
@@ -146,11 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "jPjmX7ENbXcT"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# the contents of spam get outputted\n",
@@ -160,11 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "zz6_G92vbXcd"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# only the contents of new_spam get outputted\n",
@@ -175,11 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "AFBQDYJ4bXch"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# nothing gets outputted\n",
@@ -199,11 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "iJSfQrvIbXck"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"now we have\", new_spam, \"cans of spam\")\n",
@@ -212,26 +176,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "8wMcDLCrbXco"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
     "### Hands-On Exercise\n",
-    "Remember this from before? Run this cell, then change the value of the variables `name` and `age` and run the cell again.\\\n",
+    "Remember this from before? Run this cell, then change the value of the variables `name` and `age` and run the cell again.  \n",
     "Note how the previous output gets overwritten."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "L0kV15DObXco"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "name = 'Uku' # remember, in Python you can use either ' or \" to denote strings\n",
@@ -242,10 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "JWZaZPp4bXcr"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -254,7 +208,7 @@
     "* A **list** is a *mutable* collection/sequence of values that preserves order\n",
     "* Similar to *arrays* or *vectors* in other languages, but more flexible and forgiving\n",
     "* Values can be added to or removed from a list and the entire list can be reordered\n",
-    "* A list can contain many different datatypes and even objects (other lists or data structures)\n",
+    "* A list can contain many different data types and even objects (other lists or data structures)\n",
     "* You use square brackets, **`[ ]`**, to denote a list in Python\n",
     "* Individual elements are separated by commas\n"
    ]
@@ -262,11 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "G7XaSuspbXcs"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# example of a list\n",
@@ -279,18 +229,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you are ever unsure what kind of data is stored in a variable, you can use `type()`.\\\n",
+    "If you are ever unsure what kind of data is stored in a variable, you can use `type()`.  \n",
     "*It is also a useful debugging tool.*"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9oNtFOeHbXcv"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "type(scores)"
@@ -300,8 +246,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can access elements of a list using `list[index]`. This provides both read and write functionality.\\\n",
-    "We can use it to read elements from a list but we can also use it with the assignment operator `=` to replace/overwrite elements.\\\n",
+    "We can access elements of a list using `list[index]`. This provides both read and write functionality.  \n",
+    "We can use it to read elements from a list but we can also use it with the assignment operator `=` to replace/overwrite elements.  \n",
     "However, despite the flexibility of python, you cannot use this method to add new elements to a list. Using `list[index]` with a non-existing index will result in an error.\n",
     "\n",
     "**Remember that Python uses zero-based indexing!**"
@@ -310,11 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "W_WfjenxbXcy"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# let's take a look at the first element\n",
@@ -336,7 +278,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note how the expression to the right of the assignment operator `=` always gets evaluated before the expression to the left of the assignment operator.\\\n",
+    "Note how the expression to the right of the assignment operator `=` always gets evaluated before the expression to the left of the assignment operator.  \n",
     "That allows us to easily get and overwrite the values of variables or list elements using a simple one-line statement.\n",
     "\n",
     "To check if a list contains an element, we can simply ask in English."
@@ -368,11 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "clbaJdq8bXc2"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# I just took another test and got a 70 :(\n",
@@ -400,11 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "LC0tUCSdbXc5"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "len(scores)"
@@ -420,11 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "njZmox-abXc_"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# let's look at the fist three elements\n",
@@ -435,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To slice from the beginning of the list or until the end of the list, we can just omit the respective index.\\\n",
+    "To slice from the beginning of the list or until the end of the list, we can just omit the respective index.  \n",
     "Note that you can also use negative indices to count from the end of the list."
    ]
   },
@@ -473,8 +403,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Slicing actually also has an optional third argument: `list[start:end:step]`\\\n",
-    "When we do not specify `step`, it defaults to one.\\\n",
+    "Slicing actually also has an optional third argument: `list[start:end:step]`  \n",
+    "When we do not specify `step`, it defaults to one.  \n",
     "You can still omit the `start` or `end` index as before, even when using `step`."
    ]
   },
@@ -523,7 +453,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But what if we want to see the three highest scores?\\\n",
+    "But what if we want to see the three highest scores?  \n",
     "Let's try the built-in function `sorted()`."
    ]
   },
@@ -540,7 +470,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Is there any way to change the order from ascending to descending?\\\n",
+    "Is there any way to change the order from ascending to descending?  \n",
     "We can use `help(sorted)` to find out."
    ]
   },
@@ -581,10 +511,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "KqExzhRNbXd4"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -633,10 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "KqExzhRNbXd4"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -788,7 +712,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use the `.split()` method to split a string into list elements on whitespace or any other specified string."
+    "We can use the `.split()` method to split a string into list elements on white space or any other specified string."
    ]
   },
   {
@@ -836,10 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "KqExzhRNbXd4"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -847,7 +768,7 @@
     "\n",
     "What if you want to keep a record of students in a class, their class year, their exam scores, and whether they are a graduate or an undergraduate student?\n",
     "\n",
-    "This is where dictionaries come in handy. They allow us to store related data with labels, also known as **key-value** pairs.\\\n",
+    "This is where dictionaries come in handy. They allow us to store related data with labels, also known as **key-value** pairs.  \n",
     "Dictionaries are denoted with curly braces **`{ }`** in python.\n",
     "\n",
     "More information on dictionaries: <https://docs.python.org/3/tutorial/datastructures.html#dictionaries>"
@@ -856,11 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Qrn7ZExBbXd5"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# example of a dictionary\n",
@@ -882,11 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "0tfmEUplbXd7"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "student1['first']"
@@ -895,11 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "uAAKmGAjbXd9"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "student1['scores']"
@@ -909,7 +818,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the elements of a dictionary are also *iterables* (like lists), you can use **chained indexing** to access nested elements.\\\n",
+    "If the elements of a dictionary are also *iterables* (like lists), you can use **chained indexing** to access nested elements.  \n",
     "*This also applies to other iterables like lists or arrays.*"
    ]
   },
@@ -1023,7 +932,7 @@
     "\n",
     "### Exercises involving Dictionaries\n",
     "\n",
-    "Create a new student record using the first four elements from our previous list `scores`.\\\n",
+    "Create a new student record using the first four elements from our previous list `scores`.  \n",
     "Make sure to include all of the same fields as previous student records. Make up the values for other fields except *scores*.\n",
     "\n",
     "Finally, add the newly create student to the list `students` (and verify it's there).\n",
@@ -1048,7 +957,7 @@
     "<summary><em>Click to reveal solution</em></summary>\n",
     "\n",
     "\n",
-    "> One option would be to create a new variable like above and then add it to the list of dictionaries.\\\n",
+    "> One option would be to create a new variable like above and then add it to the list of dictionaries.  \n",
     "> Or, instead, we could both create a new dictionary and add it to our list all in one line.\n",
     "> ```python\n",
     "> students.append({'first': 'Monty',\n",
@@ -1058,17 +967,14 @@
     ">                  'scores': scores[:4]})\n",
     "> ```\n",
     "\n",
-    "> Remember that you can omit the zero when slicing from the beginning of a list, hence `scores[:4]`.\\\n",
+    "> Remember that you can omit the zero when slicing from the beginning of a list, hence `scores[:4]`.  \n",
     "> Again, as this does not output anything, you would need to call `students` or use `print()` to see if it actually worked.\n",
     "</details>"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WGmbepABbXdC"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -1080,11 +986,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "zNcI16SEbXdD"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# example of a function that takes a number and output its square\n",
@@ -1106,7 +1008,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that any variables defined within a function definition are temporary and only exist within that function.\\\n",
+    "Note that any variables defined within a function definition are temporary and only exist within that function.  \n",
     "For example, the variable `sq` does not exist, even though we just used it when we called `square()`."
    ]
   },
@@ -1124,7 +1026,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We must use the `return` statement to make the function output any desired values.\\\n",
+    "We must use the `return` statement to make the function output any desired values.  \n",
     "Note that the whole expression to the right of the `return` statement gets evaluated first, and then the result of the whole expression gets outputted."
    ]
   },
@@ -1142,11 +1044,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "a0ZFCbaobXdK"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "square(3)"
@@ -1238,10 +1136,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MB6IicY_bXdU"
-   },
+   "metadata": {},
    "source": [
     "What happens if you call `square()` on a list?"
    ]
@@ -1249,11 +1144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "edyK2HOSbXdV"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "square(scores)"
@@ -1261,10 +1152,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WAJDELUWbXdY"
-   },
+   "metadata": {},
    "source": [
     "Because you do not need to specify the types of variables in Python, it is very important to think about the **type** of the input when using or defining functions.\n",
     "\n",
@@ -1298,14 +1186,14 @@
     ">     return output\n",
     "> ```\n",
     "\n",
-    "> You should always give your functions and variables short yet descriptive names.\\\n",
+    "> You should always give your functions and variables short yet descriptive names.  \n",
     "> Note that the variable `output` in the function definition above is redundant and can be omitted.\n",
     "> ```python\n",
     "> def add_forty_two(number):\n",
     ">     return number + 42\n",
     "> ```\n",
     "\n",
-    "> Also note that there is never a single right answer to these exercises. Your function might look different, but still work.\\\n",
+    "> Also note that there is never a single right answer to these exercises. Your function might look different, but still work.  \n",
     "> You should always test your function with various input and ensure the outputs are as expected.\n",
     "</details>"
    ]
@@ -1314,8 +1202,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Write a function with the following characteristics:\\\n",
-    "***Input:*** A word (string).\\\n",
+    "Write a function with the following characteristics:  \n",
+    "***Input:*** A word (string).  \n",
     "***Output:*** The same word but with `\" and spam\"` added to the end of it."
    ]
   },
@@ -1342,7 +1230,7 @@
     ">     return word + ' and spam'\n",
     "> ```\n",
     "\n",
-    "> Note that you should always use `return` to emit output from a function.\\\n",
+    "> Note that you should always use `return` to emit output from a function.  \n",
     "> Use `print()` only when the purpose of your function is actually to display content on the screen.\n",
     "</details>"
    ]
@@ -1351,8 +1239,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Write a function with the following characteristics:\\\n",
-    "***Input:*** Two numbers.\\\n",
+    "Write a function with the following characteristics:  \n",
+    "***Input:*** Two numbers.  \n",
     "***Output:*** The first number to the power of the second number.\n",
     "\n",
     "*__Bonus:__ Use a named argument and make the function square by default.\\\n",
@@ -1388,8 +1276,8 @@
     ">     return base ** exponent\n",
     "> ```\n",
     "\n",
-    "> Now you can omit `exponent` completely and the function will automatically square the `base`.\\\n",
-    "> Also note that when defining function arguments like this, you can use them both as positional and named arguments when calling the function.\\\n",
+    "> Now you can omit `exponent` completely and the function will automatically square the `base`.  \n",
+    "> Also note that when defining function arguments like this, you can use them both as positional and named arguments when calling the function.  \n",
     "> You can try this out by copying and running the code from below. Note all the different ways you can call functions.\n",
     "> ```python\n",
     "> # omitting the exponent will square the number given\n",
@@ -1414,8 +1302,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Write a function with the following characteristics:\\\n",
-    "***Input:*** A string and a number.\\\n",
+    "Write a function with the following characteristics:  \n",
+    "***Input:*** A string and a number.  \n",
     "***Output:*** The same string except the first and last letters (characters) have been duplicated by the specified number of times."
    ]
   },
@@ -1442,17 +1330,14 @@
     ">     return word[0] * x + word[1:-1] + word[-1] * x\n",
     "> ```\n",
     ">\\\n",
-    "> Remember that the last element of a list (or the last character of a string) is at index `-1`.\\\n",
+    "> Remember that the last element of a list (or the last character of a string) is at index `-1`.  \n",
     "> Again, your function could look different and span across multiple lines, but still work. This is just a compact example.\n",
     "</details>"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "BNwuw2VnbXdb"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -1464,11 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "FohQu7iwbXdc"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# let's say we want to print out each of my scores one by one\n",
@@ -1480,11 +1361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "TQv5ZIgWbXdj"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# some of the low scores make us really sad\n",
@@ -1498,11 +1375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "a6O7rGewbXdm"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# did that change our original scores?\n",
@@ -1521,11 +1394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "mFeHbOrFbXdf"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# there really are not any good examples of while loops at the beginner level\n",
@@ -1594,8 +1463,8 @@
     "\n",
     "### Sidenote: Tuples\n",
     "\n",
-    "Why did we need to use `i, scores` when we used `enumerate(grades)`?\\\n",
-    "That's because `enumerate()` returns a list of tuples.\\\n",
+    "Why did we need to use `i, scores` when we used `enumerate(grades)`?  \n",
+    "That's because `enumerate()` returns a list of tuples.  \n",
     "A **tuple** is an ordered ***unchangeable*** collection of elements."
    ]
   },
@@ -1643,16 +1512,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WAJDELUWbXdY"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
     "### Exercises involving Loops\n",
-    "Use a **for-loop** to write a function with the following characteristics:\\\n",
-    "***Input:*** A list of numbers.\\\n",
+    "Use a **for-loop** to write a function with the following characteristics:  \n",
+    "***Input:*** A list of numbers.  \n",
     "***Output:*** A copy of the input where the number 42 has been added to each element.\n",
     "\n",
     "*If nothing comes to mind at first, these hints might be of help:*\n",
@@ -1692,8 +1558,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use a **loop** to write a function with the following characteristics:\\\n",
-    "***Input:*** A number.\\\n",
+    "Use a **loop** to write a function with the following characteristics:  \n",
+    "***Input:*** A number.  \n",
     "***Output:*** The word `\"spam\"` printed out said number of times, each on a new line."
    ]
   },
@@ -1730,7 +1596,7 @@
     ">         print('spam')\n",
     "> ```\n",
     "\n",
-    "> Remember that we can use the underscore `_` to denote variables we do not care about.\\\n",
+    "> Remember that we can use the underscore `_` to denote variables we do not care about.  \n",
     "> When using `range()` in this context, we are not interested in the actual elements of the list produced by `range()` nor are they ever referenced within the loop, so using `_` is very fitting.\n",
     "</details>"
    ]
@@ -1739,10 +1605,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use `range()` to write a function that takes a list of numbers as an input, but does not output anything.\\\n",
+    "Use `range()` to write a function that takes a list of numbers as an input, but does not output anything.  \n",
     "Instead, it modifies the input list such that 42 gets added to each element.\n",
     "\n",
-    "You might be tempted use `scores` to test this function. **Do not do that!** Instead, use the provided **copy** if desired.\\\n",
+    "You might be tempted use `scores` to test this function. **Do not do that!** Instead, use the provided **copy** if desired.  \n",
     "*We will talk about the importance of the `.copy()` method in a little bit.*"
    ]
   },
@@ -1773,7 +1639,7 @@
     "<summary><em>Click to reveal solution</em></summary>\n",
     "\n",
     "\n",
-    "> To modify the elements of a list, we need to loop over the indices of the list and refer to each element via its index.\\\n",
+    "> To modify the elements of a list, we need to loop over the indices of the list and refer to each element via its index.  \n",
     "> We can use `range()` with `len()` to generate a list of index numbers to use.\n",
     "> ```python\n",
     "> def modify_list_by_adding_42(xs):\n",
@@ -1788,7 +1654,7 @@
     ">         xs[i] = x + 42\n",
     "> ```\n",
     "\n",
-    "> Note that because these functions modify the list provided as input, they do not output anything.\\\n",
+    "> Note that because these functions modify the list provided as input, they do not output anything.  \n",
     "> You should take a look at the list provided as input to see if they actually worked.\n",
     "</details>"
    ]
@@ -1828,7 +1694,7 @@
     "<summary><em>Click to reveal solution</em></summary>\n",
     "\n",
     "\n",
-    "> After some trial and error or a quick web search, you learn that using a for-loop to iterate over dictionary entires actually gives you both read and write access.\\\n",
+    "> After some trial and error or a quick web search, you learn that using a for-loop to iterate over dictionary entries actually gives you both read and write access.  \n",
     "> However, because the grades themselves are stored in a list, we must use `range()` or `enumerate()` to change them.\n",
     "> ```python\n",
     "> def curve_scores(students):\n",
@@ -1849,7 +1715,7 @@
     "\n",
     "### Lambda Functions and Mapping\n",
     "\n",
-    "Remember the function `square()` from before?\\\n",
+    "Remember the function `square()` from before?  \n",
     "Such a simple function can easily be written as a quick one-liner."
    ]
   },
@@ -1875,12 +1741,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These one-line functions called **lambda** functions, but also often referred to as *anonymous* functions.\\\n",
+    "These one-line functions called **lambda** functions, but also often referred to as *anonymous* functions.  \n",
     "That's because they do not have a name. You can easily define a lambda function as follows, without ever having to specify a function name.\n",
     "\n",
     "`lambda arguments : expression`\n",
     "\n",
-    "Note how you do not need to use `return`. The result of the one-line expression gets automatically outputted.\\\n",
+    "Note how you do not need to use `return`. The result of the one-line expression gets automatically outputted.  \n",
     "If desired, you can store a lambda function definition into a variable and use it as you would a normal function.\n",
     "\n",
     "However, the true power of lambda functions are revealed when dealing with functions that expect other functions as input. One of these functions is the built-in `map()` function. It takes a function and an iterable (list), and returns a new iterable where the function has been applied to each element. It is kind of like using a `for` loop, except it is much more efficient and often the preferred alternative to using a for loop for simple element-wise operations."
@@ -2034,9 +1900,11 @@
    "metadata": {},
    "source": [
     "---\n",
+    "\n",
     "### Exercises involving Map, Lambda, and List Comprehensions\n",
-    "Use `map()` and a `lambda` function to rewrite this function from before:\\\n",
-    "***Input:*** A list of numbers.\\\n",
+    "\n",
+    "Use `map()` and a `lambda` function to rewrite this function from before:  \n",
+    "***Input:*** A list of numbers.  \n",
     "***Output:*** A copy of the input where the number 42 has been added to each element."
    ]
   },
@@ -2097,10 +1965,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "eeTCQuzlbXdt"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -2185,18 +2050,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also stack conditionals using `else if` or `elif` to provide more functionality.\\\n",
+    "We can also stack conditionals using `else if` or `elif` to provide more functionality.  \n",
     "The conditional statements get evaluated in order, from top to bottom."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "WMGT8pakbXdv"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# knowing the letter grade ranges, we can write a function that maps a score to a letter grade\n",
@@ -2216,11 +2077,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "kewlHOogbXdz"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Now we can use a loop to get a list of letter grades from our scores\n",
@@ -2239,8 +2096,8 @@
    "source": [
     "---\n",
     "### Exercises involving Conditionals\n",
-    "Use a **conditional** and a **for-loop** to write a function with the following characteristics:\\\n",
-    "***Input:*** A list of exam scores.\\\n",
+    "Use a **conditional** and a **for-loop** to write a function with the following characteristics:  \n",
+    "***Input:*** A list of exam scores.  \n",
     "***Output:*** A new list containing only the exam scores that correspond to the letter grade **A**, in order.\n",
     "\n",
     "*If nothing comes to mind at first, these hints might be of help:*\n",
@@ -2294,7 +2151,7 @@
     "---\n",
     "\n",
     "## Advanced: Copy vs View\n",
-    "What if we would like create a copy of a list?\\\n",
+    "What if we would like create a copy of a list?  \n",
     "Our first thought would be to use the assignment operator `=` as we would with any variable."
    ]
   },
@@ -2330,7 +2187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Both lists appear identical, so it looks like it worked.\\\n",
+    "Both lists appear identical, so it looks like it worked.  \n",
     "But what if we make some modifications to the copy?"
    ]
   },
@@ -2365,9 +2222,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even though we only changed `numbers_copy`, the original list `numbers` also changed.\\\n",
-    "That is because Python optimized in the background and did not give us a **copy** of the list.\\\n",
-    "Instead, it took a shortcut and gave us a **view**, meaning that the names `numbers_copy` and `numbers` actually refer to the same object.\\\n",
+    "Even though we only changed `numbers_copy`, the original list `numbers` also changed.  \n",
+    "That is because Python optimized in the background and did not give us a **copy** of the list.  \n",
+    "Instead, it took a shortcut and gave us a **view**, meaning that the names `numbers_copy` and `numbers` actually refer to the same object.  \n",
     "This kind of behavior is often referred to as ***pass-by-reference***. While the behavior where a **copy** is returned instead is known as ***pass-by-value***.\n",
     "\n",
     "Simple (immutable) data structures like numbers are passed by ***value*** in Python, meaning that we always get a **copy**."
@@ -2432,7 +2289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, when it comes to more complex (mutable) data structures like lists, Python almost always attempts to optimize and  uses ***pass-by-reference***.\\\n",
+    "However, when it comes to more complex (mutable) data structures like lists, Python almost always attempts to optimize and  uses ***pass-by-reference***.  \n",
     "Hence, when working with iterables and other complex data structures, it is important to keep in mind that Python returns a **view** unless explicitly asked to do otherwise.\n",
     "\n",
     "To ensure we get a **copy**, we should use the `.copy()` method."
@@ -2516,10 +2373,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Zz4jF__DbXeP"
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "\n",
@@ -2531,11 +2385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "_u1uZ8rCbXeP"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -2552,11 +2402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7jLBTDIIbXeT"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# create an array and fill it with evenly spaced numbers from 0 to 2pi\n",
@@ -2616,11 +2462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "fCGLmxg9bXeX"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# define the plot\n",
@@ -2670,8 +2512,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- merge notebook updates from chbe39-intro-python
- simplify notebook header section
- update notebook intro and list sections
- explicitly specify in-text urls using angle brackets
- update and fix notebook dictionaries section
- specify difference between print and return
- update notebook loops section
- update notebook advanced sections
- update resources section and fix typos
- simplify environment specification
- restructure repository to accomodate workflows
- add build-binder and mirror-content workflows
- add preliminary readme
- overhaul workshop website
- fix typos and clarify local terminal launch instructions
- fix notebook download link
- update binder and colab links
- update tarball and zipball links
- update local python interpreter instructions
- slim down google colab instructions
- update mambaforge local notebook launch instructions
- update section titles
- add workshop overview to website
- update command-line section to work with new terminal instance
- minor updates to readme
- fix errors in terminal launch instructions
- minimize jupyterlab build
- minor updates to workshop notebook
- add develop binder launch badge to readme
- add additional resources to webiste
